### PR TITLE
Fix for issue #5

### DIFF
--- a/japi-compliance-checker.pl
+++ b/japi-compliance-checker.pl
@@ -4170,7 +4170,7 @@ sub getAffectDescription($$$$)
     elsif($TypeProblems_Kind{$Level}{$Kind})
     {
         if($Location_To_Type eq "this") {
-            return "This$ABSTRACT_M $METHOD_TYPE is from \'$Type_Name\'$ABSTRACT_C $Type_Type.";
+            return "This$ABSTRACT_M $METHOD_TYPE is from \'".htmlSpecChars($Type_Name)."\'$ABSTRACT_C $Type_Type.";
         }
         if($Location_To_Type=~/RetVal/)
         { # return value


### PR DESCRIPTION
Escapes Type_Name description to prevent HTML output to be corrupted when Type_Name is a generic type
