### PR TITLE
There is a call to a function from a missing module APIDump.

### DIFF
--- a/japi-compliance-checker.pl
+++ b/japi-compliance-checker.pl
@@ -62,6 +62,7 @@ loadModule("Filter");
 loadModule("SysFiles");
 loadModule("Descriptor");
 loadModule("Mangling");
+loadModule("APIDump");
 
 # Rules DB
 my %RULES_PATH = (


### PR DESCRIPTION
In the japi-compliance-checker at line  4772             readArchive(0, $ClientPath);
readArchive is defined in APIDump.pm at line 109, however this module "APIDump" is not included in the japi-compliance-checker, which leads to an error:
Undefined subroutine &main::readArchive called at japi-compliance-checker line 4772
when it is executed with -app or -client argument
japi-compliance-checker -app/-client -Old.jar -New.jar